### PR TITLE
Full speed

### DIFF
--- a/Handmade.xcodeproj/xcshareddata/xcschemes/Handmade (OS X).xcscheme
+++ b/Handmade.xcodeproj/xcshareddata/xcschemes/Handmade (OS X).xcscheme
@@ -68,7 +68,7 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">

--- a/src/macosx/macosx_handmade.swift
+++ b/src/macosx/macosx_handmade.swift
@@ -76,6 +76,9 @@ final class GraphicsBufferView : NSView {
         
         renderWeirdGradient(offsetX, offsetY)
 
+        let elapsed = CACurrentMediaTime() - start
+        println(elapsed)
+        
         // TODO(owensd): This will crash if there is no context
         let context = NSGraphicsContext.currentContext()!.CGContext
         
@@ -96,8 +99,7 @@ final class GraphicsBufferView : NSView {
 
         let rect = CGRect(x: 0, y: 0, width: buffer.width, height: buffer.height)
         
-        let elapsed = CACurrentMediaTime() - start
-        println("elapsed: \(elapsed)")
+        
         
         CGContextDrawImage(context, rect, image)
         

--- a/src/macosx/macosx_handmade.swift
+++ b/src/macosx/macosx_handmade.swift
@@ -41,7 +41,7 @@ struct OffscreenBuffer {
 }
 
 
-class GraphicsBufferView : NSView {
+final class GraphicsBufferView : NSView {
     var buffer = OffscreenBuffer()
     
     var offsetX = 0

--- a/src/macosx/macosx_handmade.swift
+++ b/src/macosx/macosx_handmade.swift
@@ -95,10 +95,13 @@ class GraphicsBufferView : NSView {
             provider, nil, true, kCGRenderingIntentDefault)
 
         let rect = CGRect(x: 0, y: 0, width: buffer.width, height: buffer.height)
-        CGContextDrawImage(context, rect, image)
         
         let elapsed = CACurrentMediaTime() - start
         println("elapsed: \(elapsed)")
+        
+        CGContextDrawImage(context, rect, image)
+        
+        
     }
 
     func renderWeirdGradient(blueOffset: Int, _ greenOffset: Int) {

--- a/src/macosx/macosx_handmade.swift
+++ b/src/macosx/macosx_handmade.swift
@@ -107,30 +107,18 @@ final class GraphicsBufferView : NSView {
     }
 
     func renderWeirdGradient(blueOffset: Int, _ greenOffset: Int) {
-        for var y = 0; y < buffer.height; y++ {
-            let row = y * buffer.width
-            for var x = 0; x < buffer.width; x++ {
-                // Simply using the "FAST" code block changes the timing from 1.2s
-                // per call to 0.37s per call.
-                
-                // ---- SLOW CODE BLOCK
-                // buffer.pixels[row + x].green = Byte((y + greenOffset) & 0xFF)
-                // buffer.pixels[row + x].blue = Byte((y + blueOffset) & 0xFF)
-                // ---- END SLOW CODE BLOCK
-                
-                // ---- FASTER CODE BLOCK
-                let pixel = Pixel(
-                    red: 0,
-                    green: Byte((y + greenOffset) & 0xFF),
-                    blue: Byte((x + blueOffset) & 0xFF),
-                    alpha: 255)
-                
-                
-                buffer.pixels[row + x] = pixel
-                // ---- END FASTER CODE BLOCK
+        let height = buffer.height
+        let width = buffer.width
+        buffer.pixels.withUnsafeMutableBufferPointer { pixels->() in
+            for y in 0..<height {
+                let row = y * width
+                for x in 0..<width {
+                    let i = row + x
+                    pixels[i].green = Byte((y + greenOffset) & 0xFF)
+                    pixels[i].blue = Byte((x + blueOffset) & 0xFF)
+                }
             }
         }
-        
         self.needsDisplay = true
     }
 }


### PR DESCRIPTION
Not expecting you to merge this but a PR is the easiest way to show it to you. And you might hate it even more because without optimisation it is about 200 times slower rather than just 100.

Just measuring the renderWeirdGraphics (and I made the same change to the measurement of Objective-C BackingBuffer ARC/no ARC versions) the optimized Swift runs about 40% faster than the Objective-C versions (all optimized and I tried all the -O options for the non-ARC one).
```swift
    func renderWeirdGradient(blueOffset: Int, _ greenOffset: Int) {
        let height = buffer.height
        let width = buffer.width
        buffer.pixels.withUnsafeMutableBufferPointer { pixels->() in
            for y in 0..<height {
                let row = y * width
                for x in 0..<width {
                    let i = row + x
                    pixels[i].green = Byte((y + greenOffset) & 0xFF)
                    pixels[i].blue = Byte((x + blueOffset) & 0xFF)
                }
            }
        }
        self.needsDisplay = true
    }
```